### PR TITLE
Remove reference to src in import statement

### DIFF
--- a/.github/workflows/ci-unittesting.yml
+++ b/.github/workflows/ci-unittesting.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./requirements.txt
+          pip install -e .
 
       - name: Setup dockerised Redis
         run: make dev

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from setuptools import setup
+from setuptools import find_packages
+
+SOURCE_DIRECTORY = "src"
+
+setup(name="redis-troubleshooting", version="0.1",
+      package_dir={'': SOURCE_DIRECTORY},
+      packages=find_packages(where=SOURCE_DIRECTORY))

--- a/src/redis_expire.py
+++ b/src/redis_expire.py
@@ -3,7 +3,7 @@ import time
 
 from argparse import ArgumentParser
 from pprint import pprint
-from src.redis_common import RedisCommon
+from redis_common import RedisCommon
 
 DEFAULT_REDIS_PORT = 6379
 

--- a/src/redis_flushall.py
+++ b/src/redis_flushall.py
@@ -2,7 +2,7 @@
 """Useful for Redis cluster with multiple master nodes
    as opposed to running FLUSHALL through redis-cli"""
 from argparse import ArgumentParser
-from src.redis_common import RedisCommon
+from redis_common import RedisCommon
 
 DEFAULT_REDIS_PORT = 6379
 

--- a/src/redis_slowlog.py
+++ b/src/redis_slowlog.py
@@ -3,7 +3,7 @@ import pytz
 from argparse import ArgumentParser
 from datetime import datetime
 from pprint import pprint
-from src.redis_common import RedisCommon
+from redis_common import RedisCommon
 
 
 DEFAULT_REDIS_PORT = 6379

--- a/src/redis_verify.py
+++ b/src/redis_verify.py
@@ -3,7 +3,7 @@ import time
 
 from argparse import ArgumentParser
 from pprint import pprint
-from src.redis_common import RedisCommon
+from redis_common import RedisCommon
 
 
 class RedisVerify(RedisCommon):


### PR DESCRIPTION
Fix the error `ModuleNotFoundError: No module named 'src'` when attempting to run the script as it is.